### PR TITLE
fix(utils): add error handling to drugServices

### DIFF
--- a/src/lib/components/services/drugServices.tsx
+++ b/src/lib/components/services/drugServices.tsx
@@ -2,20 +2,44 @@ import axios from "axios";
 
 const getRXCUIFromDrugName = async (name: string) => {
   const ENDPOINT = "https://rxnav.nlm.nih.gov/REST/rxcui.json";
-  const resp = await axios.get(`${ENDPOINT}?name=${name}&search=2`);
-  return resp.data.idGroup.rxnormId[0];
+  const resp = (await axios.get(`${ENDPOINT}?name=${name}&search=2`)).data;
+
+  if (resp.idGroup.keys.length !== 0) {
+    return {
+      success: true,
+      data: resp.idGroup.rxnormId[0],
+    };
+  }
+  return {
+    success: false,
+  };
 };
 
-const getInteractionsFromRXCUI = (rxcui: string) => {
+const getInteractionsFromRXCUI = async (rxcui: string) => {
   const ENDPOINT =
     "https://rxnav.nlm.nih.gov/REST/interaction/interaction.json";
-  return axios.get(`${ENDPOINT}?rxcui=${rxcui}`);
+  const resp = (await axios.get(`${ENDPOINT}?rxcui=${rxcui}`)).data;
+
+  if (resp.interactionTypeGroup !== null) {
+    return {
+      success: true,
+      data: resp.interactionTypeGroup[0].interactionType[0].interactionPair,
+    };
+  }
+
+  return {
+    success: false,
+  };
 };
 
 const getInteractionsFromDrugName = async (name: string) => {
   const rxcui = await getRXCUIFromDrugName(name);
-  return (await getInteractionsFromRXCUI(rxcui)).data.interactionTypeGroup[0]
-    .interactionType[0].interactionPair;
+
+  if (rxcui.success) {
+    return getInteractionsFromRXCUI(rxcui.data);
+  }
+
+  return rxcui;
 };
 
 const drugServices = {


### PR DESCRIPTION
All methods in drugServices are now asynchronous functions that return objects with a "success" boolean and a "data" key paired with the actual data payload

BREAKING CHANGE: Any methods that previously called methods from drugServices will now have to handle the new format for the return values